### PR TITLE
fix(notifiarr): set stable hostname

### DIFF
--- a/clusters/main/kubernetes/media/notifiarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/notifiarr/app/helm-release.yaml
@@ -69,5 +69,12 @@ spec:
                 readOnly: false
                 server: ${NAS_DOMAIN}
         release_name: notifiarr
+        workload:
+            main:
+                podSpec:
+                    containers:
+                        main:
+                            env:
+                                HOSTNAME: notifiarr
         notifiarr:
             apikey: ${NOTIFIARR_API_KEY}


### PR DESCRIPTION
## Summary
- configure the notifiarr workload to set a fixed HOSTNAME value so the pod registers with a stable name

## Testing
- kustomize build clusters/main/kubernetes *(fails: kustomize not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69386d0974b88328b8df57d6eb1da444)